### PR TITLE
Update PriceConverter.sol

### DIFF
--- a/src/PriceConverter.sol
+++ b/src/PriceConverter.sol
@@ -3,27 +3,54 @@ pragma solidity 0.8.18;
 
 import {AggregatorV3Interface} from "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
 
-// Why is this a library and not abstract?
-// Why not an interface?
 library PriceConverter {
-    // We could make this public, but then we'd have to deploy it
     function getPrice(AggregatorV3Interface priceFeed) internal view returns (uint256) {
-        // Sepolia ETH / USD Address
-        // https://docs.chain.link/data-feeds/price-feeds/addresses
-      
         (, int256 answer, , , ) = priceFeed.latestRoundData();
-        // ETH/USD rate in 18 digit
-        return uint256(answer * 10000000000);
+        return uint256(answer * 1e10);
     }
 
-    // 1000000000
-    function getConversionRate(
-        uint256 ethAmount,
-        AggregatorV3Interface priceFeed
-    ) internal view returns (uint256) {
+    function getHistoricalPrice(AggregatorV3Interface priceFeed, uint80 roundId)
+        internal
+        view
+        returns (uint256)
+    {
+        (, int256 answer, , , ) = priceFeed.getRoundData(roundId);
+        return uint256(answer * 1e10);
+    }
+
+    function getDecimals(AggregatorV3Interface priceFeed) internal view returns (uint8) {
+        return priceFeed.decimals();
+    }
+
+    function getConversionRate(uint256 ethAmount, AggregatorV3Interface priceFeed)
+        internal
+        view
+        returns (uint256)
+    {
         uint256 ethPrice = getPrice(priceFeed);
-        uint256 ethAmountInUsd = (ethPrice * ethAmount) / 1000000000000000000;
-        // the actual ETH/USD conversion rate, after adjusting the extra 0s.
-        return ethAmountInUsd;
+        return (ethPrice * ethAmount) / 1e18;
+    }
+
+    function convertUsdToEth(uint256 usdAmount, AggregatorV3Interface priceFeed)
+        internal
+        view
+        returns (uint256)
+    {
+        uint256 ethPrice = getPrice(priceFeed);
+        return (usdAmount * 1e18) / ethPrice;
+    }
+
+    function getLatestTimestamp(AggregatorV3Interface priceFeed) internal view returns (uint256) {
+        (, , , uint256 updatedAt, ) = priceFeed.latestRoundData();
+        return updatedAt;
+    }
+
+    function isPriceStale(AggregatorV3Interface priceFeed, uint256 threshold)
+        internal
+        view
+        returns (bool)
+    {
+        uint256 updatedAt = getLatestTimestamp(priceFeed);
+        return block.timestamp - updatedAt > threshold;
     }
 }


### PR DESCRIPTION
Here’s an enhanced PriceConverter library with additional abilities and features to expand its utility:

Additions:

	1.	New Functions:
	•	getHistoricalPrice: Fetches the price of a specific round.
	•	getDecimals: Retrieves the number of decimals used by the price feed.
	•	getLatestTimestamp: Fetches the latest update timestamp for the price feed.
	•	convertUsdToEth: Converts a USD amount to ETH based on the current price.
	•	isPriceStale: Checks if the price feed data is outdated based on a threshold.
